### PR TITLE
React 16 compatibility

### DIFF
--- a/src/adapters/react.js
+++ b/src/adapters/react.js
@@ -1,5 +1,4 @@
 import layerUI from '../base';
-import Layer from 'layer-websdk';
 
 /**
  * Call this function to initialize all of the react components needed to handle the Layer UI for Web widgets.
@@ -77,7 +76,7 @@ function initReact(React, ReactDom) {
       .replace(/-(.)/g, (str, value) => value.toUpperCase()))
         .replace(/^Layer/, '');
 
-    libraryResult[className] = React.createClass({
+    libraryResult[className] = class extends React.Component {
       /**
        * On mounting, copy in all properties, and optionally setup a Query.
        *
@@ -107,7 +106,7 @@ function initReact(React, ReactDom) {
           document.dispatchEvent(evt);
         }
         this.node._onAfterCreate();
-      },
+      }
 
       /**
        * Copy all properties into the dom node, but never let React recreate this widget.
@@ -130,7 +129,7 @@ function initReact(React, ReactDom) {
           }
         }, this);
         return false;
-      },
+      }
 
       handleReactDom(propDef, value) {
         if (!this.layerUIGeneratedNodes) this.layerUIGeneratedNodes = {};
@@ -157,20 +156,19 @@ function initReact(React, ReactDom) {
           ReactDom.render(value, this.layerUIGeneratedNodes[propDef.propertyName]);
         }
         return this.layerUIGeneratedNodes[propDef.propertyName];
-      },
-
+      }
 
       render() {
         return React.createElement(componentName, {
           ref: (node) => { this.node = node; },
           id: this.props.id,
         });
-      },
-    });
+      }
+    };
   });
+
   return libraryResult;
 }
 
 module.exports = initReact;
 layerUI.addAdapter('react', initReact);
-


### PR DESCRIPTION
React.createClass was deprecated in React 15, and removed entirely in React 16, which was released yesterday.

Using ES6 classes is the preferred method of creating components.

We are using this fork in production with React 16 without issues.

See: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.createclass